### PR TITLE
Active committers from API and improved max coverage algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,57 @@
 # GHAS Activation and Coverage Optimization
 
-The idea of the project is to optimize the utilization of GHAS licenses within your organization. GHAS has a licensing model that is based on active committers. Each active committer will consume a GHAS license. This means that any repositories to which this committer is contributing could have GHAS enabled.
+The purpose of this project is to optimize the utilization of GHAS (GitHub Advanced Security) licenses within your organization. GHAS operates on a licensing model based on active committers. Each active committer consumes one GHAS license, meaning GHAS can be enabled for any repository to which this committer contributes.
 
 **Example:**
 
-- Developer A is contributing to 3 repositories - `Repo1`, `Repo2`, `Repo5`.
-- Developer B is contributing to 2 repositories - `Repo2`, `Repo5`.
+- Developer A contributes to 3 repositories - `Repo1`, `Repo2`, `Repo5`.
+- Developer B contributes to 2 repositories - `Repo2`, `Repo5`.
 - GHAS is enabled on `Repo1` and `Repo2`.
-- Developer A and B are both active committers for `Repo5` as well.
-- GHAS can be enabled on `Repo5` without consuming additional GHAS licenses.
+- Both Developer A and B are active committers to `Repo5`.
+- Enabling GHAS on `Repo5` does not require additional GHAS licenses.
 
 ## Use Cases
 
-There are three primary use cases for this tool to help fulfill:
+This tool assists in three primary practical scenarios:
 
-1. Increase the coverage of GHAS within your organization by enabling GHAS on repositories that do not require extra licenses.
+1. **Increase GHAS Coverage:**
+   You've already enabled GHAS a few months ago according to your rollout plan and have utilized all the GHAS licenses you purchased. Now, you believe that new repositories have been created or migrated, where GHAS can be enabled without needing additional licenses. Your goal is to identify these repositories and activate GHAS on them.
 
-    You enabled GHAS a few months ago as per your rollout plan and have consumed all the GHAS licenses you purchased. You think that there are new repositories that were created, some repositories that were migrated in the meantime, where GHAS can be enabled without consuming extra licenses. You want to find those repositories and enable GHAS on them.
+2. **Optimize GHAS Coverage:**
+   A few months ago, you activated GHAS on your business critical repositories and still have a certain number of GHAS licenses available. Your objective is to discover repositories that can be activated with the existing licenses and also to find the most extensive combinations of repositories that can be enabled with the extra licenses you have.
 
-2. Optimize the coverage of GHAS within your organization with the current number of licenses and find the maximum coverage that can be achieved with the extra licenses available.
-
-    You enabled GHAS a few months ago on your business-critical repositories, and you have N number of GHAS licenses still available. You want to find the repositories that can be enabled with the current licenses but also find the longest combinations of repositories that you can enable with the extra licenses available.
-
-3. Find which repositories to start GHAS enablement in an organization to achieve the maximum coverage with the licenses available.
-
-    You have purchased GHAS licenses, and you are planning your GHAS rollout. You know that you have more active committers than the number of purchased licenses, but you have one factor for the rollout, and that is to enable GHAS features on as many repositories as possible. You want to find the longest combination of repositories that you can enable with the licenses you have just bought and start your rollout.
+3. **Strategic GHAS Rollout:**
+   Having purchased GHAS licenses, you are now planning your GHAS rollout. You are aware that the number of active committers exceeds the number of licenses you have. However, your primary focus is to enable GHAS features on as many repositories as possible. You aim to identify the most extensive combination of repositories that can be enabled with the licenses you've acquired and initiate your rollout.
 
 ## How the Script Works
 
-The Python script takes the following inputs:
+The Python script processes the following inputs:
 
-- Active committers: CSV report about active committers in your enterprise.
+- Active committers:
+    1. Parsing a CSV report on maximum active committers in your enterprise, or [preferably]
+    2. Finding active committers via the GraphQL API (experimental and slower).
 - GitHub Enterprise slug.
 - GitHub Organization slug.
 - GitHub Personal Access Token.
-- Licenses available.
+- Number of available GHAS licenses.
 - Output file name.
 - Output file format (Text or JSON).
 
-It will first gather the list of all repositories in the enterprise or organization and their GHAS enabled status and create a list of objects. It will then parse the `Active committers` report and add the active committers to each repository object.
+The script first compiles a list of all repositories within the enterprise and/or organization(s), including their GHAS status. It then processes the `Max active committers` report or fetches active committers for each repository using the GraphQL API, adding this data to each repository object.
 
-The script will then go through the list and find the repositories that will not require extra GHAS licenses to enable. It will categorize those into two groups: repositories whose active committers already consume a GHAS license and repositories that do not have active committers.
+Next, the script identifies repositories that can be enabled with GHAS without requiring additional licenses, categorizing them into three groups:
 
-For the leftover repositories, if provided with a number of licenses available, it will find the longest combination of repositories that can be enabled within the available licenses limit.
+- Repositories whose active committers already consume a GHAS license.
+- Public repositories not requiring a GHAS license for enablement.
+- Repositories without active committers.
 
-It will then output the results into a file according to the output preferences.
+For remaining repositories, given the number of available licenses, the script determines the longest combination of repositories that can be enabled within the license limit.
+
+Finally, it outputs the results in the chosen file format.
 
 ### Active Committers
 
-The maximum active committers report is a CSV file that contains the following columns:
+The script uses the `Max active committers` report or the GraphQL API to obtain the list of active committers for each repository. The maximum active committers report is preferred way as it runs the script faster and is more reliable. The GraphQL API is experimental and slower but can be used if the `Max active committers` report is not available.
 
 ```csv
 User login,Organization / repository,Last pushed date
@@ -57,11 +60,9 @@ theztefan,thez-org/repo_name3,2023-10-06
 theztefan,thez-org/repo_name2,2023-08-06
 ```
 
-We will be using the Stafftools UI to generate this report.
-
 ### GHAS Status
 
-We obtain the GHAS status for each repository in an organization by calling the `GET /orgs/{org}/repos` API endpoint.
+The GHAS status for each repository in an organization is obtained by calling the GET /orgs/{org}/repos API endpoint.
 
 ## Output Report
 
@@ -174,6 +175,33 @@ or `JSON` for machine-parseable output to plug in your GHAS enablement automatio
         },
        ...
     ],
+    "current_repos_without_ghas_and_public": [
+        {
+            "name": "go-gin-example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-07-03T08:59:02Z",
+            "active_committers": []
+        },
+        {
+            "name": "rails-ex",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-03T16:00:58Z",
+            "active_committers": []
+        },
+        {
+            "name": "rails-react-typescript-docker-example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-10T12:15:50Z",
+            "active_committers": []
+        },
+        ...
+    ],
     "new_active_committers": [
         "hill-scribes-0x"
     ],
@@ -199,58 +227,74 @@ or `JSON` for machine-parseable output to plug in your GHAS enablement automatio
 
 ```text
 $ python3 main.py --help
-usage: main.py [-h] --ac-report AC_REPORT [--enterprise ENTERPRISE] [--organization ORGANIZATION] [--output OUTPUT] [--output-format OUTPUT_FORMAT]
-               [--token TOKEN] [--licenses LICENSES]
+usage: main.py [-h] [--ac-report AC_REPORT] [--enterprise ENTERPRISE] [--organization ORGANIZATION] [--output OUTPUT] [--output-format OUTPUT_FORMAT] [--token TOKEN] [--licenses LICENSES]
 
-GHAS Activation and Coverage Activation
+GHAS activation and coverage activation
 
 options:
   -h, --help            show this help message and exit
   --ac-report AC_REPORT
-                        Path to the active committers report (required)
+                        Path to the active committers report
   --enterprise ENTERPRISE
                         Name of the enterprise
   --organization ORGANIZATION
                         Name of the organization
   --output OUTPUT       Path to the output file (default: 'report.md')
   --output-format OUTPUT_FORMAT
-                        Output format - text or JSON (default: 'text')
-  --token TOKEN         GitHub Personal Access Token (if not set in GITHUB_TOKEN environment variable)
+                        Output format - text or json (default: 'text')
+  --token TOKEN         GitHub Personal Access Token (if not set in GITHUB_TOKEN envrionment variable)
   --licenses LICENSES   Number of (still) available GHAS licenses (default: 0)
 ```
 
+You would need to provide:
+
+- `--ac-report` with the path to the Max Active Committers report. If left empty, the script will gather the data from the GraphQL API.
+- `--organization` and/or `--enterprise` parameters to specify the scope of the script.
+
 ### Prerequisites
 
-- Python 3.9+
-- Personal Access Token (PAT) with permissions depending on the scope you plan to run it - `repo`, `admin:org`, `admin:enterprise`
-- Active committers report saved locally
+- Python 3.9 or later.
+- Personal Access Token (PAT) with permissions depending on the scope you plan to run it - `repo`, `admin:org`, `admin:enterprise`.
+- Active committers report saved locally.
 
 ### Running
 
-- Create a virtual environment - `python3 -m venv venv`
-- Activate your virtual environment - `source venv/bin/activate`
-- Install dependencies  `pip3 install -r requirements.txt`
-- Set GitHub PAT into `GITHUB_TOKEN` environment variable - `export GITHUB_TOKEN=<token>`
-- Run the script `python3 main.py --ac-report REPORT.csv --org ORG`
+1. Create a virtual environment: `python3 -m venv venv`.
+2. Activate your virtual environment: `source venv/bin/activate`.
+3. Install dependencies: `pip3 install -r requirements.txt`.
+4. Set the GitHub PAT in the `GITHUB_TOKEN` environment variable: `export GITHUB_TOKEN=<token>`.
+5. Run the script: `python3 main.py --ac-report REPORT.csv --org ORG`.
 
 ### Examples
 
-1. Increase the coverage of GHAS within your organization by enabling GHAS on repositories that do not require extra licenses.
+1. **Increase the coverage of GHAS** within your organization by enabling GHAS on repositories that do not require extra licenses.
 
     ```shell
-    python3 main.py --ac-report ghas_maximum_committers_thezorg.csv --org thez-org --output-format text --output report.md
+    # With Active Commiters Report available
+    python3 main.py --ac-report ghas_maximum_committers_thezorg.csv --org thez-org --output-format text --output report.md   
+
+    # Gather Active Committers from API
+    python3 main.py --org thez-org --output-format text --output report.md 
     ```
 
-2. Optimize the coverage of GHAS within your organization with the current number of licenses and find the maximum coverage that can be achieved with the extra licenses available.
+2. **Optimize the coverage of GHAS** within your organization with the current number of licenses and find the maximum coverage that can be achieved with the extra licenses available.
 
     ```shell
-    python3 main.py --ac-report ghas_maximum_committers_thezorg.csv --org thez-org --licenses 10  --output-format text --output report.md
+    # With Active Commiters Report available
+    python3 main.py --ac-report ghas_maximum_committers_thezorg.csv --org thez-org --licenses 10  --output-format text --output report.md   
+    
+    # Gather Active Committers from API
+    python3 main.py --org thez-org --licenses 10  --output-format text --output report.md   
     ```
 
     **Note: After enabling GHAS on the new repositories to get maximum coverage, you will want to re-run the script again to see if there are any new repositories that can be enabled with the new active committers. Currently, the script doesn't calculate the new coverage after enabling GHAS on the new repositories.**
 
-3. Find which repositories to start GHAS enablement in an organization to achieve the maximum coverage with the licenses available.
+3. **Strategic GHAS rollout** by finding the repositories to achieve the maximum coverage with the licenses available.
 
     ```shell
-    python3 main.py --ac-report ghas_maximum_committers_thezorg.csv --org thez-org --licenses 600  --output-format json --output report.json
+    # With Active Commiters Report available
+    python3 main.py --ac-report ghas_maximum_committers_thezorg.csv --org thez-org --licenses 600  --output-format json --output report.json    
+
+    # Gather Active Commiters from API
+    python3 main.py --org thez-org --licenses 600  --output-format json --output report.json    
     ```

--- a/github.py
+++ b/github.py
@@ -1,5 +1,65 @@
 import requests
+import csv
+import time
+import threading
+import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta
 from models import Repository
+from helpers import *
+
+logger = get_logger()
+
+
+RATE_LIMIT_LOCK = threading.Lock()
+MAX_WORKERS = 5
+
+
+def add_active_committers(report, repositories, token):
+    try:
+        with open(report, "r") as file:
+            reader = csv.reader(file)
+            next(reader)  # Skip the header row
+            for row in reader:
+                user_login, org_repo, *_ = row
+                org, repo_name = org_repo.split("/")
+                for repo in repositories:
+                    if repo.name == repo_name and repo.org == org:
+                        repo.add_committer(user_login)
+    except (Exception, TypeError) as e:
+        logger.info(f"Fetching active committers from GitHub API...")
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [
+                executor.submit(
+                    get_active_committers_in_last_90_days, repo.org, repo.name, token
+                )
+                for repo in repositories
+            ]
+            for i, future in enumerate(
+                concurrent.futures.as_completed(futures), start=1
+            ):
+                repo = repositories[i - 1]
+                logger.info(
+                    f"[{i}/{len(repositories)}] Processing repository: {repo.get_full_name()}"
+                )
+                repo.add_active_committers(future.result())
+
+
+def get_organizations(args, token):
+    orgs_in_ent = []
+    if not args.enterprise:
+        orgs_in_ent.append(args.organization)
+    else:
+        orgs_in_ent = get_orgs_in_ent(args.enterprise, token)
+    return orgs_in_ent
+
+
+def process_organizations(orgs_in_ent, token):
+    total_repositories = []
+    for i, org in enumerate(orgs_in_ent, start=1):
+        logger.info(f"[{i}/{len(orgs_in_ent)}] Processing organization: {org}")
+        total_repositories.extend(get_ghas_status_for_repos(org, token))
+    return total_repositories
 
 
 def get_ghas_status_for_repos(org, token):
@@ -10,6 +70,9 @@ def get_ghas_status_for_repos(org, token):
 
     while True:
         response = requests.get(url, headers=headers, params={"page": page})
+
+        handle_rate_limit(response)
+
         data = response.json()
         for repo_data in data:
             owner, name = repo_data["full_name"].split("/")
@@ -19,13 +82,104 @@ def get_ghas_status_for_repos(org, token):
                 .get("status", "")
                 == "enabled"
             )
+            visibility = repo_data["visibility"]
             pushed_at = repo_data["pushed_at"]
-            repo = Repository(name, owner, ghas_status, pushed_at)
+            repo = Repository(name, owner, ghas_status, visibility, pushed_at)
             repos.append(repo)
         if "next" not in response.links:
             break
         page += 1
+
     return repos
+
+
+def get_active_committers_in_last_90_days(org, repo, token):
+    url = "https://api.github.com/graphql"
+    headers = {"Authorization": f"token {token}"}
+    active_committers = set()
+
+    end_cursor = None
+    while True:
+        query = """
+        query getCommitters($org: String!, $repo: String!, $since: GitTimestamp!, $after: String) {
+            repository(owner: $org, name: $repo) {
+                visibility
+                refs(refPrefix: "refs/heads/", first: 100) {
+                    nodes {
+                        name
+                        target {
+                            ... on Commit {
+                                history(first: 100, since: $since, after: $after) {
+                                    nodes {
+                                        author {
+                                            user {
+                                                login
+                                            }
+                                        }
+                                    }
+                                    pageInfo {
+                                        endCursor
+                                        hasNextPage
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    pageInfo {
+                        endCursor
+                        hasNextPage
+                    }
+                }
+            }
+        }
+        """
+        hasNextPage = False
+        since = (datetime.now() - timedelta(days=90)).isoformat()
+        variables = {"org": org, "repo": repo, "since": since, "after": end_cursor}
+        payload = {"query": query, "variables": variables}
+        response = requests.post(url, headers=headers, json=payload)
+
+        handle_rate_limit(response)
+
+        if response.status_code != 200:
+            logger.info(f"Response: {response.json()}")
+            next
+
+        if response.status_code == 401:
+            logger.info(f"Insufficient permissions token provided.")
+            break
+
+        data = response.json()
+        repository = data["data"]["repository"]
+        refs = repository.get("refs")
+        visibility = repository.get("visibility")
+
+        # only process if repository is not public
+        if visibility != "PUBLIC":
+            if refs:
+                nodes = refs.get("nodes", [])
+                for ref in nodes:
+                    target = ref.get("target", {})
+                    history = target.get("history") if target else None
+                    if history:
+                        commits = history.get("nodes", [])
+                        for commit in commits:
+                            user = commit["author"]["user"]
+                            if user:
+                                author = user["login"]
+                                active_committers.add(author)
+                        end_cursor = history.get("pageInfo", {}).get("endCursor")
+                        hasNextPage = history.get("pageInfo", {}).get("hasNextPage")
+
+        if not refs or not hasNextPage:
+            break
+
+        handle_rate_limit(response)
+
+    # Remove dependabot[bot] from active committers
+    active_committers.discard("dependabot[bot]")
+
+    return list(active_committers)
 
 
 def get_orgs_in_ent(enterprise_name, token):
@@ -52,6 +206,9 @@ def get_orgs_in_ent(enterprise_name, token):
         variables = {"enterprise": enterprise_name, "after": end_cursor}
         payload = {"query": query, "variables": variables}
         response = requests.post(url, headers=headers, json=payload)
+
+        handle_rate_limit(response)
+
         data = response.json()
         orgs += [
             org["login"] for org in data["data"]["enterprise"]["organizations"]["nodes"]
@@ -62,4 +219,31 @@ def get_orgs_in_ent(enterprise_name, token):
             ]
         else:
             break
+
+        handle_rate_limit(response)
     return orgs
+
+
+def handle_rate_limit(response):
+    # Check the rate limit
+    remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+    if remaining < 50:
+        logger.info(f"Rate limit close to being exceeded. Slowing down requests...")
+        time.sleep(5)
+    if remaining == 0 or response.status_code in [403, 429]:
+        with RATE_LIMIT_LOCK:
+            remaining = int(response.headers.get("X-RateLimit-Remaining", 0))
+            if remaining == 0 or response.status_code in [403, 429]:
+                logger.info(f"Headers: {response.headers}")
+                if "Retry-After" in response.headers:
+                    sleep_time = int(response.headers["Retry-After"]) + 2
+                else:
+                    reset_time = int(response.headers.get("X-RateLimit-Reset", 0))
+                    sleep_time = max(
+                        reset_time - time.time() + 2, 1
+                    )  # Ensure sleep time is at least 1 second
+                logger.info(
+                    f"Rate limit exceeded. Sleeping for {sleep_time} seconds..."
+                )
+                time.sleep(sleep_time)
+    time.sleep(1)  # Sleep for 1 second anyways to avoid hitting rate limit

--- a/helpers.py
+++ b/helpers.py
@@ -19,8 +19,8 @@ def parse_arguments():
     parser.add_argument(
         "--ac-report",
         type=str,
-        help="Path to the active committers report (required)",
-        required=True,
+        help="Path to the active committers report",
+        required=False,
     )
     parser.add_argument(
         "--enterprise", type=str, help="Name of the enterprise", required=False

--- a/main.py
+++ b/main.py
@@ -7,23 +7,6 @@ load_dotenv()
 logger = get_logger()
 
 
-def get_organizations(args, token):
-    orgs_in_ent = []
-    if not args.enterprise:
-        orgs_in_ent.append(args.organization)
-    else:
-        orgs_in_ent = get_orgs_in_ent(args.enterprise, token)
-    return orgs_in_ent
-
-
-def process_organizations(orgs_in_ent, token):
-    total_repositories = []
-    for i, org in enumerate(orgs_in_ent, start=1):
-        logger.info(f"[{i}/{len(orgs_in_ent)}] Processing organization: {org}")
-        total_repositories.extend(get_ghas_status_for_repos(org, token))
-    return total_repositories
-
-
 def main():
     # Parse arguments provided
     args, token = parse_arguments()
@@ -31,10 +14,10 @@ def main():
     # Gather all data needed for the report - all orgs in the enterprise, repositories in orgs and active committers in repositories
     orgs_in_ent = get_organizations(args, token)
     logger.info(f"Number of organizations to process: {len(orgs_in_ent)}")
-
     total_repositories = process_organizations(orgs_in_ent, token)
+
     logger.info(f"Adding active committers to {len(total_repositories)} repositories")
-    add_active_committers(args.ac_report, total_repositories)
+    add_active_committers(args.ac_report, total_repositories, token)
 
     # Generate report and print report
     logger.info(f"Generating report...")

--- a/models.py
+++ b/models.py
@@ -1,5 +1,7 @@
 class Repository:
-    def __init__(self, name, org, ghas_status, pushed_at, active_committers=None):
+    def __init__(
+        self, name, org, ghas_status, visibility, pushed_at, active_committers=None
+    ):
         self.name = name
         self.org = org
         self.ghas_status = ghas_status
@@ -7,9 +9,13 @@ class Repository:
         self.active_committers = (
             active_committers if active_committers is not None else []
         )
+        self.visibility = visibility
 
     def add_committer(self, committer):
         self.active_committers.append(committer)
+
+    def add_active_committers(self, committers):
+        self.active_committers.extend(committers)
 
     def get_active_committers(self):
         return self.active_committers
@@ -23,14 +29,18 @@ class Repository:
     def get_full_name(self):
         return self.org + "/" + self.name
 
+    def get_visibility(self):
+        return self.visibility
+
     def __str__(self):
-        return f"Repository: {self.name} | GHAS Status: {self.ghas_status} | Last Pushed At: {self.pushed_at} | Active Committers: {self.active_committers}"
+        return f"Repository: {self.name} | GHAS Status: {self.ghas_status} | Visibility: {self.visibility} | Last Pushed At: {self.pushed_at} | Active Committers: {self.active_committers}"
 
     def to_dict(self):
         return {
             "name": self.name,
             "org": self.org,
             "ghas_status": self.ghas_status,
+            "visibility": self.visibility,
             "pushed_at": self.pushed_at,
             "active_committers": self.active_committers,
         }
@@ -45,6 +55,7 @@ class Report:
         current_repos_with_ghas=[],
         current_repos_without_ghas_with_active_committers=[],
         current_repos_without_ghas_and_committers=[],
+        current_repos_without_ghas_and_public=[],
         new_active_committers=set(),
         max_coverage_repos=[],
     ):
@@ -57,6 +68,9 @@ class Report:
         )
         self.current_repos_without_ghas_and_committers = (
             current_repos_without_ghas_and_committers
+        )
+        self.current_repos_without_ghas_and_public = (
+            current_repos_without_ghas_and_public
         )
         self.new_active_committers = new_active_committers
         self.max_coverage_repos = max_coverage_repos
@@ -86,6 +100,7 @@ class Report:
         sum_activated_repos = (
             len(self.current_repos_without_ghas_with_active_committers)
             + len(self.current_repos_without_ghas_and_committers)
+            + len(self.current_repos_without_ghas_and_public)
             + self.total_current_repos_with_ghas
             + len(self.max_coverage_repos)
         )
@@ -97,6 +112,7 @@ class Report:
             self.total_current_repos_with_ghas
             + len(self.current_repos_without_ghas_and_committers)
             + len(self.current_repos_without_ghas_with_active_committers)
+            + len(self.current_repos_without_ghas_and_public)
             + len(self.max_coverage_repos)
         )
 
@@ -113,6 +129,8 @@ class Report:
             \tRepos without GHAS and Active Committers: {', '.join(f"{repo.name} ({', '.join(repo.get_active_committers())})" for repo in self.current_repos_without_ghas_with_active_committers)} \n'
             Total Repositories without GHAS and Committers: {len(self.current_repos_without_ghas_and_committers)} \n
             \tRepos without GHAS and Committers: {', '.join(repo.name for repo in self.current_repos_without_ghas_and_committers)} \n
+            Total Repositories without GHAS and Public: {len(self.current_repos_without_ghas_and_public)} \n
+            \tRepos without GHAS and Public: {', '.join(repo.name for repo in self.current_repos_without_ghas_and_public)} \n
             Total New Active Committers: {len(self.new_active_committers)} \n
             \tNew Active Committers: {', '.join(self.new_active_committers)} \n
             Repositories to Max Coverage: {len(self.max_coverage_repos)} \n
@@ -134,6 +152,9 @@ class Report:
             "current_repos_without_ghas_and_committers": [
                 repo.to_dict()
                 for repo in self.current_repos_without_ghas_and_committers
+            ],
+            "current_repos_without_ghas_and_public": [
+                repo.to_dict() for repo in self.current_repos_without_ghas_and_public
             ],
             "new_active_committers": list(self.new_active_committers),
             "max_coverage_repos": [repo.to_dict() for repo in self.max_coverage_repos],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 setuptools
 python-dotenv
+colorama

--- a/sample_report.json
+++ b/sample_report.json
@@ -4,15 +4,15 @@
             "name": "open-book",
             "org": "thez-org",
             "ghas_status": true,
-            "pushed_at": "2023-10-25T12:25:07Z",
-            "active_committers": [
-                "theztefan"
-            ]
+            "visibility": "internal",
+            "pushed_at": "2023-11-22T11:39:41Z",
+            "active_committers": []
         },
         {
             "name": "ado-project-migration",
             "org": "thez-org",
             "ghas_status": false,
+            "visibility": "internal",
             "pushed_at": "2022-05-12T10:54:04Z",
             "active_committers": []
         },
@@ -20,6 +20,7 @@
             "name": "new-secret-demo",
             "org": "thez-org",
             "ghas_status": false,
+            "visibility": "internal",
             "pushed_at": "2023-02-24T16:31:40Z",
             "active_committers": []
         },
@@ -27,6 +28,7 @@
             "name": "dependancy-compare",
             "org": "thez-org",
             "ghas_status": false,
+            "visibility": "internal",
             "pushed_at": "2023-07-24T13:37:04Z",
             "active_committers": []
         },
@@ -34,23 +36,360 @@
             "name": "octo-gallery",
             "org": "thez-org",
             "ghas_status": false,
+            "visibility": "internal",
             "pushed_at": "2023-07-25T18:43:20Z",
-            "active_committers": []
+            "active_committers": [
+                "theztefan"
+            ]
         },
         {
             "name": "gradle-dependancy-test",
             "org": "thez-org",
             "ghas_status": false,
+            "visibility": "internal",
             "pushed_at": "2023-09-06T15:09:18Z",
             "active_committers": []
+        },
+        {
+            "name": "elc-demo",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-07-09T03:04:58Z",
+            "active_committers": []
+        },
+        {
+            "name": "hm-demo",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-10-17T21:37:47Z",
+            "active_committers": []
+        },
+        {
+            "name": "new-test-repo",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2022-12-16T13:23:15Z",
+            "active_committers": []
+        },
+        {
+            "name": "goserver",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-01-09T16:36:30Z",
+            "active_committers": []
+        },
+        {
+            "name": "autodep",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-01-12T14:17:21Z",
+            "active_committers": []
+        },
+        {
+            "name": "autodep-priv",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "private",
+            "pushed_at": "2023-01-12T14:17:41Z",
+            "active_committers": []
+        },
+        {
+            "name": "exercise-enable-code-scanning-using-codeql",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "private",
+            "pushed_at": "2023-01-19T13:27:57Z",
+            "active_committers": []
+        },
+        {
+            "name": "exercise-remove-commit-history",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "private",
+            "pushed_at": "2023-01-19T13:31:20Z",
+            "active_committers": []
+        },
+        {
+            "name": "ghas-devtraining-gusshawstewart",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "private",
+            "pushed_at": "2023-02-03T13:11:39Z",
+            "active_committers": []
+        },
+        {
+            "name": "go-gin-example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-07-03T08:59:02Z",
+            "active_committers": []
+        },
+        {
+            "name": "rails-ex",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-03T16:00:58Z",
+            "active_committers": []
+        },
+        {
+            "name": "rails-react-typescript-docker-example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-10T12:15:50Z",
+            "active_committers": []
+        },
+        {
+            "name": "python-twilio-example-apps",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-02-21T11:14:38Z",
+            "active_committers": []
+        },
+        {
+            "name": "fibonacci-webapp-benchmark",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-02-22T15:33:22Z",
+            "active_committers": []
+        },
+        {
+            "name": "terraform-test",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-02-23T11:46:53Z",
+            "active_committers": []
+        },
+        {
+            "name": "auth0-golang-web-app",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-02-28T08:59:47Z",
+            "active_committers": []
+        },
+        {
+            "name": "webapp-go",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-02-28T08:59:43Z",
+            "active_committers": []
+        },
+        {
+            "name": "sysfoo",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-01T08:26:30Z",
+            "active_committers": []
+        },
+        {
+            "name": "WebApp",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-01T08:27:14Z",
+            "active_committers": []
+        },
+        {
+            "name": "WebApplicationSkeleton",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-01T08:26:38Z",
+            "active_committers": []
+        },
+        {
+            "name": "micro-frontend-example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-01T08:40:34Z",
+            "active_committers": []
+        },
+        {
+            "name": "serverless-web-app-example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-01T08:40:38Z",
+            "active_committers": []
+        },
+        {
+            "name": "react-redux-example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-01T08:54:02Z",
+            "active_committers": []
+        },
+        {
+            "name": "scan-public-actions",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-03-14T11:36:51Z",
+            "active_committers": []
+        },
+        {
+            "name": "msdocs-python-flask-webapp-quickstart",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2022-11-05T01:52:32Z",
+            "active_committers": []
+        },
+        {
+            "name": "imagebird",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-02T15:48:07Z",
+            "active_committers": []
+        },
+        {
+            "name": "python-desktop-examples",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-02T16:30:12Z",
+            "active_committers": []
+        },
+        {
+            "name": "python-geeks",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-02T15:53:00Z",
+            "active_committers": []
+        },
+        {
+            "name": "Scheduling-App",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-06T10:22:59Z",
+            "active_committers": []
+        },
+        {
+            "name": "python-ecommerce",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-02T16:33:00Z",
+            "active_committers": []
+        },
+        {
+            "name": "wechat_jump_game",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-02T16:36:18Z",
+            "active_committers": []
+        },
+        {
+            "name": "uvicorn-poetry",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-03T12:02:05Z",
+            "active_committers": []
+        },
+        {
+            "name": "sandcage-api-python",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-03T12:07:41Z",
+            "active_committers": []
+        },
+        {
+            "name": "braintree_rails_example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-03T16:04:44Z",
+            "active_committers": []
+        },
+        {
+            "name": "vulnerable-app",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2018-02-07T12:02:03Z",
+            "active_committers": []
+        },
+        {
+            "name": "vulnerable-node",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-07-27T11:09:36Z",
+            "active_committers": []
+        },
+        {
+            "name": "vulnerable-node-2",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-04-12T13:30:17Z",
+            "active_committers": []
+        },
+        {
+            "name": "central-config",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-07-24T13:36:49Z",
+            "active_committers": []
+        },
+        {
+            "name": "test-public",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-10-11T12:39:53Z",
+            "active_committers": []
+        },
+        {
+            "name": "empty-one",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "private",
+            "pushed_at": "2023-10-25T12:47:33Z",
+            "active_committers": [
+                "theztefan"
+            ]
         },
         {
             "name": "hilly",
             "org": "thez-org",
             "ghas_status": false,
+            "visibility": "internal",
             "pushed_at": "2023-11-01T11:43:43Z",
             "active_committers": [
                 "hill-scribes-0x",
+                "theztefan"
+            ]
+        },
+        {
+            "name": "dep-review-test",
+            "org": "thez-org",
+            "ghas_status": true,
+            "visibility": "internal",
+            "pushed_at": "2023-11-13T16:29:51Z",
+            "active_committers": [
                 "theztefan"
             ]
         }
@@ -67,7 +406,16 @@
             "name": "open-book",
             "org": "thez-org",
             "ghas_status": true,
-            "pushed_at": "2023-10-25T12:25:07Z",
+            "visibility": "internal",
+            "pushed_at": "2023-11-22T11:39:41Z",
+            "active_committers": []
+        },
+        {
+            "name": "dep-review-test",
+            "org": "thez-org",
+            "ghas_status": true,
+            "visibility": "internal",
+            "pushed_at": "2023-11-13T16:29:51Z",
             "active_committers": [
                 "theztefan"
             ]
@@ -75,9 +423,20 @@
     ],
     "current_repos_without_ghas_with_active_committers": [
         {
+            "name": "octo-gallery",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-07-25T18:43:20Z",
+            "active_committers": [
+                "theztefan"
+            ]
+        },
+        {
             "name": "empty-one",
             "org": "thez-org",
             "ghas_status": false,
+            "visibility": "private",
             "pushed_at": "2023-10-25T12:47:33Z",
             "active_committers": [
                 "theztefan"
@@ -89,6 +448,7 @@
             "name": "ado-project-migration",
             "org": "thez-org",
             "ghas_status": false,
+            "visibility": "internal",
             "pushed_at": "2022-05-12T10:54:04Z",
             "active_committers": []
         },
@@ -96,6 +456,7 @@
             "name": "new-secret-demo",
             "org": "thez-org",
             "ghas_status": false,
+            "visibility": "internal",
             "pushed_at": "2023-02-24T16:31:40Z",
             "active_committers": []
         },
@@ -103,13 +464,329 @@
             "name": "dependancy-compare",
             "org": "thez-org",
             "ghas_status": false,
+            "visibility": "internal",
             "pushed_at": "2023-07-24T13:37:04Z",
+            "active_committers": []
+        },
+        {
+            "name": "gradle-dependancy-test",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-09-06T15:09:18Z",
+            "active_committers": []
+        },
+        {
+            "name": "elc-demo",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-07-09T03:04:58Z",
+            "active_committers": []
+        },
+        {
+            "name": "hm-demo",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-10-17T21:37:47Z",
+            "active_committers": []
+        },
+        {
+            "name": "new-test-repo",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2022-12-16T13:23:15Z",
+            "active_committers": []
+        },
+        {
+            "name": "goserver",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-01-09T16:36:30Z",
+            "active_committers": []
+        },
+        {
+            "name": "autodep",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-01-12T14:17:21Z",
+            "active_committers": []
+        },
+        {
+            "name": "autodep-priv",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "private",
+            "pushed_at": "2023-01-12T14:17:41Z",
+            "active_committers": []
+        },
+        {
+            "name": "exercise-enable-code-scanning-using-codeql",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "private",
+            "pushed_at": "2023-01-19T13:27:57Z",
+            "active_committers": []
+        },
+        {
+            "name": "exercise-remove-commit-history",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "private",
+            "pushed_at": "2023-01-19T13:31:20Z",
+            "active_committers": []
+        },
+        {
+            "name": "ghas-devtraining-gusshawstewart",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "private",
+            "pushed_at": "2023-02-03T13:11:39Z",
+            "active_committers": []
+        },
+        {
+            "name": "scan-public-actions",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-03-14T11:36:51Z",
+            "active_committers": []
+        },
+        {
+            "name": "central-config",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "internal",
+            "pushed_at": "2023-07-24T13:36:49Z",
+            "active_committers": []
+        }
+    ],
+    "current_repos_without_ghas_and_public": [
+        {
+            "name": "go-gin-example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-07-03T08:59:02Z",
+            "active_committers": []
+        },
+        {
+            "name": "rails-ex",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-03T16:00:58Z",
+            "active_committers": []
+        },
+        {
+            "name": "rails-react-typescript-docker-example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-10T12:15:50Z",
+            "active_committers": []
+        },
+        {
+            "name": "python-twilio-example-apps",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-02-21T11:14:38Z",
+            "active_committers": []
+        },
+        {
+            "name": "fibonacci-webapp-benchmark",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-02-22T15:33:22Z",
+            "active_committers": []
+        },
+        {
+            "name": "terraform-test",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-02-23T11:46:53Z",
+            "active_committers": []
+        },
+        {
+            "name": "auth0-golang-web-app",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-02-28T08:59:47Z",
+            "active_committers": []
+        },
+        {
+            "name": "webapp-go",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-02-28T08:59:43Z",
+            "active_committers": []
+        },
+        {
+            "name": "sysfoo",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-01T08:26:30Z",
+            "active_committers": []
+        },
+        {
+            "name": "WebApp",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-01T08:27:14Z",
+            "active_committers": []
+        },
+        {
+            "name": "WebApplicationSkeleton",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-01T08:26:38Z",
+            "active_committers": []
+        },
+        {
+            "name": "micro-frontend-example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-01T08:40:34Z",
+            "active_committers": []
+        },
+        {
+            "name": "serverless-web-app-example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-01T08:40:38Z",
+            "active_committers": []
+        },
+        {
+            "name": "react-redux-example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-01T08:54:02Z",
+            "active_committers": []
+        },
+        {
+            "name": "msdocs-python-flask-webapp-quickstart",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2022-11-05T01:52:32Z",
+            "active_committers": []
+        },
+        {
+            "name": "imagebird",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-02T15:48:07Z",
+            "active_committers": []
+        },
+        {
+            "name": "python-desktop-examples",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-02T16:30:12Z",
+            "active_committers": []
+        },
+        {
+            "name": "python-geeks",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-02T15:53:00Z",
+            "active_committers": []
+        },
+        {
+            "name": "Scheduling-App",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-06T10:22:59Z",
+            "active_committers": []
+        },
+        {
+            "name": "python-ecommerce",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-02T16:33:00Z",
+            "active_committers": []
+        },
+        {
+            "name": "wechat_jump_game",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-02T16:36:18Z",
+            "active_committers": []
+        },
+        {
+            "name": "uvicorn-poetry",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-03T12:02:05Z",
+            "active_committers": []
+        },
+        {
+            "name": "sandcage-api-python",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-03T12:07:41Z",
+            "active_committers": []
+        },
+        {
+            "name": "braintree_rails_example",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-03-03T16:04:44Z",
+            "active_committers": []
+        },
+        {
+            "name": "vulnerable-app",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2018-02-07T12:02:03Z",
+            "active_committers": []
+        },
+        {
+            "name": "vulnerable-node",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-07-27T11:09:36Z",
+            "active_committers": []
+        },
+        {
+            "name": "vulnerable-node-2",
+            "org": "thez-org",
+            "ghas_status": false,
+            "visibility": "public",
+            "pushed_at": "2023-04-12T13:30:17Z",
             "active_committers": []
         },
         {
             "name": "test-public",
             "org": "thez-org",
             "ghas_status": false,
+            "visibility": "public",
             "pushed_at": "2023-10-11T12:39:53Z",
             "active_committers": []
         }
@@ -122,6 +799,7 @@
             "name": "hilly",
             "org": "thez-org",
             "ghas_status": false,
+            "visibility": "internal",
             "pushed_at": "2023-11-01T11:43:43Z",
             "active_committers": [
                 "hill-scribes-0x",

--- a/sample_report.md
+++ b/sample_report.md
@@ -1,74 +1,75 @@
-# GHAS activation and coverage optimization 
+# GHAS activation and coverage optimization
 
 ------------------------------------------------------------
 # Current coverage
 
 Total active committers: 2
-Total repositories with GHAS: 1
+Total repositories with GHAS: 2
 Total repositories without GHAS: 46
-Coverage: 2.13%
+Coverage: 4.17%
 ----------------------------------------
-# Increase coverage with currently consumed licenses 
+# Increase coverage with currently consumed licenses
 
 **Turning GHAS on following repositories will not consume additional licenses**
 - Repositories with active committers already consume GHAS license:
-	 -  Repository: empty-one | GHAS Status: False | Last Pushed At: 2023-10-25T12:47:33Z | Active Committers: ['theztefan']
-- Repositories without active committers:
-	 -  Repository: ado-project-migration | GHAS Status: False | Last Pushed At: 2022-05-12T10:54:04Z | Active Committers: []
-	 -  Repository: new-secret-demo | GHAS Status: False | Last Pushed At: 2023-02-24T16:31:40Z | Active Committers: []
-	 -  Repository: dependancy-compare | GHAS Status: False | Last Pushed At: 2023-07-24T13:37:04Z | Active Committers: []
-	 -  Repository: octo-gallery | GHAS Status: False | Last Pushed At: 2023-07-25T18:43:20Z | Active Committers: []
-	 -  Repository: gradle-dependancy-test | GHAS Status: False | Last Pushed At: 2023-09-06T15:09:18Z | Active Committers: []
-	 -  Repository: elc-demo | GHAS Status: False | Last Pushed At: 2023-07-09T03:04:58Z | Active Committers: []
-	 -  Repository: hm-demo | GHAS Status: False | Last Pushed At: 2023-10-17T21:37:47Z | Active Committers: []
-	 -  Repository: new-test-repo | GHAS Status: False | Last Pushed At: 2022-12-16T13:23:15Z | Active Committers: []
-	 -  Repository: goserver | GHAS Status: False | Last Pushed At: 2023-01-09T16:36:30Z | Active Committers: []
-	 -  Repository: autodep | GHAS Status: False | Last Pushed At: 2023-01-12T14:17:21Z | Active Committers: []
-	 -  Repository: autodep-priv | GHAS Status: False | Last Pushed At: 2023-01-12T14:17:41Z | Active Committers: []
-	 -  Repository: exercise-enable-code-scanning-using-codeql | GHAS Status: False | Last Pushed At: 2023-01-19T13:27:57Z | Active Committers: []
-	 -  Repository: exercise-remove-commit-history | GHAS Status: False | Last Pushed At: 2023-01-19T13:31:20Z | Active Committers: []
-	 -  Repository: ghas-devtraining-gusshawstewart | GHAS Status: False | Last Pushed At: 2023-02-03T13:11:39Z | Active Committers: []
-	 -  Repository: go-gin-example | GHAS Status: False | Last Pushed At: 2023-07-03T08:59:02Z | Active Committers: []
-	 -  Repository: rails-ex | GHAS Status: False | Last Pushed At: 2023-03-03T16:00:58Z | Active Committers: []
-	 -  Repository: rails-react-typescript-docker-example | GHAS Status: False | Last Pushed At: 2023-03-10T12:15:50Z | Active Committers: []
-	 -  Repository: python-twilio-example-apps | GHAS Status: False | Last Pushed At: 2023-02-21T11:14:38Z | Active Committers: []
-	 -  Repository: fibonacci-webapp-benchmark | GHAS Status: False | Last Pushed At: 2023-02-22T15:33:22Z | Active Committers: []
-	 -  Repository: terraform-test | GHAS Status: False | Last Pushed At: 2023-02-23T11:46:53Z | Active Committers: []
-	 -  Repository: auth0-golang-web-app | GHAS Status: False | Last Pushed At: 2023-02-28T08:59:47Z | Active Committers: []
-	 -  Repository: webapp-go | GHAS Status: False | Last Pushed At: 2023-02-28T08:59:43Z | Active Committers: []
-	 -  Repository: sysfoo | GHAS Status: False | Last Pushed At: 2023-03-01T08:26:30Z | Active Committers: []
-	 -  Repository: WebApp | GHAS Status: False | Last Pushed At: 2023-03-01T08:27:14Z | Active Committers: []
-	 -  Repository: WebApplicationSkeleton | GHAS Status: False | Last Pushed At: 2023-03-01T08:26:38Z | Active Committers: []
-	 -  Repository: micro-frontend-example | GHAS Status: False | Last Pushed At: 2023-03-01T08:40:34Z | Active Committers: []
-	 -  Repository: serverless-web-app-example | GHAS Status: False | Last Pushed At: 2023-03-01T08:40:38Z | Active Committers: []
-	 -  Repository: react-redux-example | GHAS Status: False | Last Pushed At: 2023-03-01T08:54:02Z | Active Committers: []
-	 -  Repository: scan-public-actions | GHAS Status: False | Last Pushed At: 2023-03-14T11:36:51Z | Active Committers: []
-	 -  Repository: msdocs-python-flask-webapp-quickstart | GHAS Status: False | Last Pushed At: 2022-11-05T01:52:32Z | Active Committers: []
-	 -  Repository: imagebird | GHAS Status: False | Last Pushed At: 2023-03-02T15:48:07Z | Active Committers: []
-	 -  Repository: python-desktop-examples | GHAS Status: False | Last Pushed At: 2023-03-02T16:30:12Z | Active Committers: []
-	 -  Repository: python-geeks | GHAS Status: False | Last Pushed At: 2023-03-02T15:53:00Z | Active Committers: []
-	 -  Repository: Scheduling-App | GHAS Status: False | Last Pushed At: 2023-03-06T10:22:59Z | Active Committers: []
-	 -  Repository: python-ecommerce | GHAS Status: False | Last Pushed At: 2023-03-02T16:33:00Z | Active Committers: []
-	 -  Repository: wechat_jump_game | GHAS Status: False | Last Pushed At: 2023-03-02T16:36:18Z | Active Committers: []
-	 -  Repository: uvicorn-poetry | GHAS Status: False | Last Pushed At: 2023-03-03T12:02:05Z | Active Committers: []
-	 -  Repository: sandcage-api-python | GHAS Status: False | Last Pushed At: 2023-03-03T12:07:41Z | Active Committers: []
-	 -  Repository: braintree_rails_example | GHAS Status: False | Last Pushed At: 2023-03-03T16:04:44Z | Active Committers: []
-	 -  Repository: vulnerable-app | GHAS Status: False | Last Pushed At: 2018-02-07T12:02:03Z | Active Committers: []
-	 -  Repository: vulnerable-node | GHAS Status: False | Last Pushed At: 2023-07-27T11:09:36Z | Active Committers: []
-	 -  Repository: vulnerable-node-2 | GHAS Status: False | Last Pushed At: 2023-04-12T13:30:17Z | Active Committers: []
-	 -  Repository: central-config | GHAS Status: False | Last Pushed At: 2023-07-24T13:36:49Z | Active Committers: []
-	 -  Repository: test-public | GHAS Status: False | Last Pushed At: 2023-10-11T12:39:53Z | Active Committers: []
+	 -  Repository: octo-gallery | GHAS Status: False | Visibility: internal | Last Pushed At: 2023-07-25T18:43:20Z | Active Committers: ['theztefan']
+	 -  Repository: empty-one | GHAS Status: False | Visibility: private | Last Pushed At: 2023-10-25T12:47:33Z | Active Committers: ['theztefan']
+- Public repositories (do not required GHAS license):
+	 -  Repository: go-gin-example | GHAS Status: False | Visibility: public | Last Pushed At: 2023-07-03T08:59:02Z | Active Committers: []
+	 -  Repository: rails-ex | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-03T16:00:58Z | Active Committers: []
+	 -  Repository: rails-react-typescript-docker-example | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-10T12:15:50Z | Active Committers: []
+	 -  Repository: python-twilio-example-apps | GHAS Status: False | Visibility: public | Last Pushed At: 2023-02-21T11:14:38Z | Active Committers: []
+	 -  Repository: fibonacci-webapp-benchmark | GHAS Status: False | Visibility: public | Last Pushed At: 2023-02-22T15:33:22Z | Active Committers: []
+	 -  Repository: terraform-test | GHAS Status: False | Visibility: public | Last Pushed At: 2023-02-23T11:46:53Z | Active Committers: []
+	 -  Repository: auth0-golang-web-app | GHAS Status: False | Visibility: public | Last Pushed At: 2023-02-28T08:59:47Z | Active Committers: []
+	 -  Repository: webapp-go | GHAS Status: False | Visibility: public | Last Pushed At: 2023-02-28T08:59:43Z | Active Committers: []
+	 -  Repository: sysfoo | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-01T08:26:30Z | Active Committers: []
+	 -  Repository: WebApp | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-01T08:27:14Z | Active Committers: []
+	 -  Repository: WebApplicationSkeleton | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-01T08:26:38Z | Active Committers: []
+	 -  Repository: micro-frontend-example | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-01T08:40:34Z | Active Committers: []
+	 -  Repository: serverless-web-app-example | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-01T08:40:38Z | Active Committers: []
+	 -  Repository: react-redux-example | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-01T08:54:02Z | Active Committers: []
+	 -  Repository: msdocs-python-flask-webapp-quickstart | GHAS Status: False | Visibility: public | Last Pushed At: 2022-11-05T01:52:32Z | Active Committers: []
+	 -  Repository: imagebird | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-02T15:48:07Z | Active Committers: []
+	 -  Repository: python-desktop-examples | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-02T16:30:12Z | Active Committers: []
+	 -  Repository: python-geeks | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-02T15:53:00Z | Active Committers: []
+	 -  Repository: Scheduling-App | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-06T10:22:59Z | Active Committers: []
+	 -  Repository: python-ecommerce | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-02T16:33:00Z | Active Committers: []
+	 -  Repository: wechat_jump_game | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-02T16:36:18Z | Active Committers: []
+	 -  Repository: uvicorn-poetry | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-03T12:02:05Z | Active Committers: []
+	 -  Repository: sandcage-api-python | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-03T12:07:41Z | Active Committers: []
+	 -  Repository: braintree_rails_example | GHAS Status: False | Visibility: public | Last Pushed At: 2023-03-03T16:04:44Z | Active Committers: []
+	 -  Repository: vulnerable-app | GHAS Status: False | Visibility: public | Last Pushed At: 2018-02-07T12:02:03Z | Active Committers: []
+	 -  Repository: vulnerable-node | GHAS Status: False | Visibility: public | Last Pushed At: 2023-07-27T11:09:36Z | Active Committers: []
+	 -  Repository: vulnerable-node-2 | GHAS Status: False | Visibility: public | Last Pushed At: 2023-04-12T13:30:17Z | Active Committers: []
+	 -  Repository: test-public | GHAS Status: False | Visibility: public | Last Pushed At: 2023-10-11T12:39:53Z | Active Committers: []
+- Private and Internal repositories without active committers:
+	 -  Repository: ado-project-migration | GHAS Status: False | Visibility: internal | Last Pushed At: 2022-05-12T10:54:04Z | Active Committers: []
+	 -  Repository: new-secret-demo | GHAS Status: False | Visibility: internal | Last Pushed At: 2023-02-24T16:31:40Z | Active Committers: []
+	 -  Repository: dependancy-compare | GHAS Status: False | Visibility: internal | Last Pushed At: 2023-07-24T13:37:04Z | Active Committers: []
+	 -  Repository: gradle-dependancy-test | GHAS Status: False | Visibility: internal | Last Pushed At: 2023-09-06T15:09:18Z | Active Committers: []
+	 -  Repository: elc-demo | GHAS Status: False | Visibility: internal | Last Pushed At: 2023-07-09T03:04:58Z | Active Committers: []
+	 -  Repository: hm-demo | GHAS Status: False | Visibility: internal | Last Pushed At: 2023-10-17T21:37:47Z | Active Committers: []
+	 -  Repository: new-test-repo | GHAS Status: False | Visibility: internal | Last Pushed At: 2022-12-16T13:23:15Z | Active Committers: []
+	 -  Repository: goserver | GHAS Status: False | Visibility: internal | Last Pushed At: 2023-01-09T16:36:30Z | Active Committers: []
+	 -  Repository: autodep | GHAS Status: False | Visibility: internal | Last Pushed At: 2023-01-12T14:17:21Z | Active Committers: []
+	 -  Repository: autodep-priv | GHAS Status: False | Visibility: private | Last Pushed At: 2023-01-12T14:17:41Z | Active Committers: []
+	 -  Repository: exercise-enable-code-scanning-using-codeql | GHAS Status: False | Visibility: private | Last Pushed At: 2023-01-19T13:27:57Z | Active Committers: []
+	 -  Repository: exercise-remove-commit-history | GHAS Status: False | Visibility: private | Last Pushed At: 2023-01-19T13:31:20Z | Active Committers: []
+	 -  Repository: ghas-devtraining-gusshawstewart | GHAS Status: False | Visibility: private | Last Pushed At: 2023-02-03T13:11:39Z | Active Committers: []
+	 -  Repository: scan-public-actions | GHAS Status: False | Visibility: internal | Last Pushed At: 2023-03-14T11:36:51Z | Active Committers: []
+	 -  Repository: central-config | GHAS Status: False | Visibility: internal | Last Pushed At: 2023-07-24T13:36:49Z | Active Committers: []
 ----------------------------------------
 # Maximize coverage with additional licenses 
 
 **Turning GHAS on following repositories will consume 1 additional licenses**
 - Combination of repositories to activate GHAS on:
-	 -  Repository: hilly | GHAS Status: False | Last Pushed At: 2023-11-01T11:43:43Z | Active Committers: ['hill-scribes-0x', 'theztefan']
+	 -  Repository: hilly | GHAS Status: False | Visibility: internal | Last Pushed At: 2023-11-01T11:43:43Z | Active Committers: ['hill-scribes-0x', 'theztefan']
 
  New active comitters that will consume GHAS license:
 	 -  hill-scribes-0x
 ----------------------------------------
 # End state coverage 
 
-Total repositories with GHAS: 47
+Total repositories with GHAS: 48
 Coverage: 100.0%

--- a/tests/custom_test_runner.py
+++ b/tests/custom_test_runner.py
@@ -1,0 +1,39 @@
+import time
+import unittest
+from colorama import Fore, Style
+
+
+class CustomTestResult(unittest.TestResult):
+    def startTest(self, test):
+        self.start_time = time.time()
+        super().startTest(test)
+        print(Fore.BLUE + f"\n# Starting {test}" + Style.RESET_ALL)
+
+    def stopTest(self, test):
+        super().stopTest(test)
+        print(Fore.LIGHTBLUE_EX + f" -> 🏁 Finished {test}" + Style.RESET_ALL)
+        print(
+            Fore.LIGHTBLACK_EX
+            + f" -> ⏱️ Execution time {time.time() - self.start_time} seconds"
+            + Style.RESET_ALL
+        )
+
+    def addSuccess(self, test):
+        super().addSuccess(test)
+        print(Fore.GREEN + f"\n -> Test: {test} ✅ PASSED" + Style.RESET_ALL)
+
+    def addFailure(self, test, err):
+        super().addFailure(test, err)
+        print(Fore.RED + f"\n -> Test: {test} ⛔ FAILED" + Style.RESET_ALL)
+
+
+class CustomTextTestRunner(unittest.TextTestRunner):
+    resultclass = CustomTestResult
+
+    def run(self, test):
+        result = super().run(test)
+        if result.wasSuccessful():
+            print(Fore.GREEN + f"\n# Test {test} PASSED" + Style.RESET_ALL)
+        else:
+            print(Fore.RED + f"\n# Test {test} FAILED" + Style.RESET_ALL)
+        return result

--- a/tests/test_active_committers.py
+++ b/tests/test_active_committers.py
@@ -1,0 +1,64 @@
+import sys, os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import unittest
+from custom_test_runner import CustomTextTestRunner
+from datetime import datetime
+from github import get_active_committers_in_last_90_days, get_ghas_status_for_repos
+from github import add_active_committers
+from models import Repository
+from main import process_organizations
+from helpers import get_logger
+
+logger = get_logger()
+
+
+class TestActiveCommitters(unittest.TestCase):
+    def setUp(self):
+        self.org = "thez-org"
+        self.repo = "hilly"
+        self.token = os.getenv("GITHUB_TOKEN")
+        self.report = "test-report.csv"
+        self.repositories = [
+            Repository(self.repo, self.org, False, datetime.now().isoformat(), None)
+        ]
+
+    def test_active_committers_one_repo(self):
+        # Get active committers using get_active_committers_in_last_90_days()
+        active_committers_1 = get_active_committers_in_last_90_days(
+            self.org, self.repo, self.token
+        )
+
+        # Get active committers using add_active_committers()
+        add_active_committers(self.report, self.repositories, self.token)
+        active_committers_2 = self.repositories[0].get_active_committers()
+
+        # Compare the results
+        self.assertCountEqual(active_committers_1, active_committers_2)
+
+    def test_active_committers_one_org_all_repos(self):
+        # Get all repositories for the organization
+        all_repos = process_organizations([self.org], self.token)
+        add_active_committers(self.report, all_repos, self.token)
+
+        for repo in all_repos:
+            # Get active committers using get_active_committers_in_last_90_days()
+            active_committers_1 = get_active_committers_in_last_90_days(
+                self.org, repo.name, self.token
+            )
+
+            active_committers_2 = repo.get_active_committers()
+            # Compare the results
+            logger.info(
+                f"Comparing active committers for {repo.name} - {repo.org} - {len(active_committers_1)} - {len(active_committers_2)} - GraphQL API: {active_committers_1} - CSV: {active_committers_2}"
+            )
+            self.assertCountEqual(active_committers_1, active_committers_2)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+if __name__ == "__main__":
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestActiveCommitters)
+    CustomTextTestRunner().run(suite)

--- a/tests/test_max_coverage.py
+++ b/tests/test_max_coverage.py
@@ -1,0 +1,120 @@
+import sys, os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import unittest
+import random
+from datetime import datetime
+from custom_test_runner import CustomTextTestRunner
+from colorama import Fore, Style
+from models import Repository
+from report import (
+    find_combination_with_max_repositories_greedy,
+    find_combination_with_max_repositories,
+)
+
+
+class TestMaxRepositoriesCoverageAlgorithm(unittest.TestCase):
+    def test_find_combination_with_max_repositories_brueforce(self):
+        no_repos = 20
+        no_users = 20
+        license_count = 5
+
+        repositories = [
+            Repository(
+                name=f"repo{i}",
+                org="org",
+                ghas_status=random.choice(["enabled", "disabled"]),
+                visibility="private",
+                pushed_at=datetime.now().isoformat(),
+                active_committers=[
+                    f"user{j}" for j in range(random.randint(1, no_users))
+                ],
+            )
+            for i in range(no_repos)
+        ]
+
+        combination, unique_committers = find_combination_with_max_repositories(
+            repositories, license_count, set()
+        )
+
+        # Check that the number of unique active committers does not exceed the license limit
+        self.assertLessEqual(len(unique_committers), license_count)
+
+        print(f"Number of unique active committers: {len(unique_committers)}")
+        print(f"Number of repositories in the combination: {len(combination)}")
+        print(f"The unique active committers are: {unique_committers}")
+        # print(f"The combination: {[str(repo) for repo in combination]}")
+
+        # Check that all repositories in the combination are in the original list
+        for repo in combination:
+            self.assertIn(repo, repositories)
+
+    def test_find_combination_with_max_repositories_greedy(self):
+        no_repos = 2000
+        no_users = 20
+        license_count = 5
+
+        repositories = [
+            Repository(
+                name=f"repo{i}",
+                org="org",
+                ghas_status=random.choice(["enabled", "disabled"]),
+                visibility="private",
+                pushed_at=datetime.now().isoformat(),
+                active_committers=[
+                    f"user{j}" for j in range(random.randint(1, no_users))
+                ],
+            )
+            for i in range(no_repos)
+        ]
+
+        combination, unique_committers = find_combination_with_max_repositories_greedy(
+            repositories, license_count, set()
+        )
+
+        # Check that the number of unique active committers does not exceed the license limit
+        self.assertLessEqual(len(unique_committers), license_count)
+
+        print(f"Number of unique active committers: {len(unique_committers)}")
+        print(f"Number of repositories in the combination: {len(combination)}")
+        print(f"The unique active committers are: {unique_committers}")
+
+        # Check that all repositories in the combination are in the original list
+        for repo in combination:
+            self.assertIn(repo, repositories)
+
+    def test_find_combination_with_max_repositories_bruteforce_vs_greedy(self):
+        no_repos = 20
+        no_users = 20
+        no_license = 5
+        # Create a mock list of 200 repositories
+        repositories = [
+            Repository(
+                name=f"repo{i}",
+                org="org",
+                ghas_status=random.choice(["enabled", "disabled"]),
+                visibility="private",
+                pushed_at=datetime.now().isoformat(),
+                active_committers=[
+                    f"user{j}" for j in range(random.randint(1, no_users))
+                ],
+            )
+            for i in range(no_repos)
+        ]
+        result1, _ = find_combination_with_max_repositories(
+            repositories, no_license, set()
+        )
+        result2, _ = find_combination_with_max_repositories_greedy(
+            repositories, no_license, set()
+        )
+        self.assertEqual(
+            set(repo.name for repo in result1), set(repo.name for repo in result2)
+        )
+
+
+if __name__ == "__main__":
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(
+        TestMaxRepositoriesCoverageAlgorithm
+    )
+    CustomTextTestRunner().run(suite)


### PR DESCRIPTION
- If `max active committers` csv report is not available and provided to the script it will fallback to fetching the active committers for each repo via the GraphQL API.

- The brute force max coverage algo to find the longest combination of repositories that match number of active committers with available GHAS license had ridiculous time complexity and made the script unusable for more then few hundred repos. Switched to a new greedy algo to resolve this. 

- Wrote some tests to test the: GraphQL API active committers vs `max active committers` csv repot from StaffTools, brute force vs greedy max coverage algo

- Copilot updated the README